### PR TITLE
Fix: delete automatic setting of attributes for nodes

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -5,6 +5,6 @@ license          'The MIT License (MIT)'
 description      'SSL key & certificate storage in chef-vault.'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 
-version "1.2.0"
+version "1.2.1"
 supports 'ubuntu'
 depends 'chef-vault'

--- a/recipes/certificate_file.rb
+++ b/recipes/certificate_file.rb
@@ -38,6 +38,4 @@ node['ssl-vault']['certificates'].each do |cert_name, info|
         group 'root'
         mode '0644'
     end
-
-    node.set['ssl-vault']['certificate'][cert_name]['certificate_file'] = certificate_file
 end

--- a/recipes/combined_chain_file.rb
+++ b/recipes/combined_chain_file.rb
@@ -44,7 +44,5 @@ node['ssl-vault']['certificates'].each do |cert_name, info|
             :chain_certificates => vault_item['chain_certificates']
             )
         end
-
-        node.set['ssl-vault']['certificate'][cert_name]['combined_chain_file'] = combined_chain_file
     end
 end

--- a/recipes/combined_chain_pem_file.rb
+++ b/recipes/combined_chain_pem_file.rb
@@ -45,7 +45,5 @@ node['ssl-vault']['certificates'].each do |cert_name, info|
             :key => vault_item['key']
             )
         end
-
-        node.set['ssl-vault']['certificate'][cert_name]['combined_chain_pem_file'] = combined_chain_pem_file
     end
 end

--- a/recipes/pem_file.rb
+++ b/recipes/pem_file.rb
@@ -39,6 +39,4 @@ node['ssl-vault']['certificates'].each do |cert_name, info|
       :certificate => vault_item['certificate']
     )
   end
-
-  node.set['ssl-vault']['certificate'][cert_name]['pem_file'] = pem_file
 end

--- a/recipes/private_key_file.rb
+++ b/recipes/private_key_file.rb
@@ -38,6 +38,4 @@ node['ssl-vault']['certificates'].each do |cert_name, info|
         group node['ssl-vault']['cert_group']
         mode '0440'
     end
-
-    node.set['ssl-vault']['certificate'][cert_name]['private_key_file'] = private_key
 end


### PR DESCRIPTION
If attributes are set manually in node, there is an useless duplicatation.
Most `node.set['ssl-vault']['certificate']` in each recipes contains a mistake, example:
```
node.set['ssl-vault']['certificate'][cert_name]['certificate_file'] = certificate_file
```
it's node.set['ssl-vault']['**certificates**'] instead of node.set['ssl-vault']['certificate']