### PR TITLE
[fix] error NilClass when certificate's infos not precised

### DIFF
--- a/recipes/certificate_file.rb
+++ b/recipes/certificate_file.rb
@@ -20,7 +20,7 @@ node['ssl-vault']['certificates'].each do |cert_name, info|
     )
     vault_item = chef_vault_item('ssl-vault', clean_name)
 
-    certificate_file = if info["certificate_file"]
+    certificate_file = if info && info["certificate_file"]
         File.join(
         node['ssl-vault']['certificate_directory'],
         info["certificate_file"]

--- a/recipes/combined_chain_file.rb
+++ b/recipes/combined_chain_file.rb
@@ -22,7 +22,7 @@ node['ssl-vault']['certificates'].each do |cert_name, info|
 
     if vault_item.key?('chain_certificates') and vault_item['chain_certificates']
 
-        combined_chain_file = if info["combined_chain_file"]
+        combined_chain_file = if info && info["combined_chain_file"]
             File.join(
             node['ssl-vault']['certificate_directory'],
             info["combined_chain_file"]

--- a/recipes/combined_chain_pem_file.rb
+++ b/recipes/combined_chain_pem_file.rb
@@ -22,7 +22,7 @@ node['ssl-vault']['certificates'].each do |cert_name, info|
 
     if vault_item.key?('chain_certificates') and vault_item['chain_certificates']
 
-        combined_chain_pem_file = if info['combined_chain_pem_file']
+        combined_chain_pem_file = if info && info['combined_chain_pem_file']
             File.join(
             node['ssl-vault']['private_key_directory'],
             info['combined_chain_pem_file']

--- a/recipes/pem_file.rb
+++ b/recipes/pem_file.rb
@@ -20,7 +20,7 @@ node['ssl-vault']['certificates'].each do |cert_name, info|
   )
   vault_item = chef_vault_item('ssl-vault', clean_name)
 
-  pem_file = if info['pem_file']
+  pem_file = if info && info['pem_file']
     info['pem_file']
   else
     File.join(

--- a/recipes/private_key_file.rb
+++ b/recipes/private_key_file.rb
@@ -20,7 +20,7 @@ node['ssl-vault']['certificates'].each do |cert_name, info|
     )
     vault_item = chef_vault_item('ssl-vault', clean_name)
 
-    private_key = if info['private_key_file']
+    private_key = if info && info['private_key_file']
         File.join(
         node['ssl-vault']['private_key_directory'],
         info['private_key_file']


### PR DESCRIPTION
If Certificates isn't a Hash, info is a NilClass and ruby break. 